### PR TITLE
Mark Xeno/Resurgent Tree as protected from cutting

### DIFF
--- a/1.6/Biotech_Genes/Defs/ThingDefs_Trees/Plant_ResurgentTree.xml
+++ b/1.6/Biotech_Genes/Defs/ThingDefs_Trees/Plant_ResurgentTree.xml
@@ -83,6 +83,7 @@
 		<initialGrowthRange>0.2~0.8</initialGrowthRange>
 		<canSpawnOverPlayerSownPlants>false</canSpawnOverPlayerSownPlants>
 	  </li>
+	  <li Class="CompProperties_PlantPreventCutting"/>
 	  <!-- <li Class="WVC_XenotypesAndGenes.CompProperties_RandomName"> -->
 		<!-- <nameMaker>WVC_XenotypesAndGenes_MushroomTreeNames</nameMaker> -->
 	  <!-- </li> -->

--- a/1.6/Biotech_Genes/Defs/ThingDefs_Trees/Plant_XenoTree.xml
+++ b/1.6/Biotech_Genes/Defs/ThingDefs_Trees/Plant_XenoTree.xml
@@ -71,6 +71,7 @@
 		<minGrowthForSpawn>0.6</minGrowthForSpawn>
 		<initialGrowthRange>0.2~0.8</initialGrowthRange>
 		<canSpawnOverPlayerSownPlants>false</canSpawnOverPlayerSownPlants>
+		<li Class="CompProperties_PlantPreventCutting"/>
 		<!-- <plantsToNotOverwrite> -->
 		  <!-- <li>Plant_PodGauranlen</li> -->
 		  <!-- <li MayRequire="Ludeon.RimWorld.Royalty">Plant_GrassAnima</li> -->

--- a/1.6/Biotech_Genes/Defs/ThingDefs_Trees/Plant_XenoTree.xml
+++ b/1.6/Biotech_Genes/Defs/ThingDefs_Trees/Plant_XenoTree.xml
@@ -71,7 +71,6 @@
 		<minGrowthForSpawn>0.6</minGrowthForSpawn>
 		<initialGrowthRange>0.2~0.8</initialGrowthRange>
 		<canSpawnOverPlayerSownPlants>false</canSpawnOverPlayerSownPlants>
-		<li Class="CompProperties_PlantPreventCutting"/>
 		<!-- <plantsToNotOverwrite> -->
 		  <!-- <li>Plant_PodGauranlen</li> -->
 		  <!-- <li MayRequire="Ludeon.RimWorld.Royalty">Plant_GrassAnima</li> -->
@@ -81,6 +80,7 @@
 		  <!-- <li MayRequire="Ludeon.RimWorld.Ideology">Plant_TreeGauranlen</li> -->
 		<!-- </plantsToNotOverwrite> -->
 	  </li>
+	  <li Class="CompProperties_PlantPreventCutting"/>
 	</comps>
   </ThingDef>
 


### PR DESCRIPTION
Really small pull request that makes the trees protected from cutting, same as the other super trees.
Motivated by the little agrihand that could plant a xeno tree in my tree growing zone and then immediately cut it down again.