### PR TITLE
fix crashes, null dereferences, performance issues, and float menu options

### DIFF
--- a/Source/Resources_Abilities/CompAbilityEffect_BloodfeederBite.cs
+++ b/Source/Resources_Abilities/CompAbilityEffect_BloodfeederBite.cs
@@ -56,25 +56,26 @@ namespace WVC_XenotypesAndGenes
 
 		public override bool Valid(LocalTargetInfo target, bool throwMessages = false)
 		{
-			if (target.HasThing && target.Thing is Corpse corpse)
+			if (!target.HasThing || target.Thing is not Corpse corpse || corpse.InnerPawn == null)
 			{
-				Pawn innerPawn = corpse.InnerPawn;
-				if (innerPawn.IsAndroid() || target.Thing.IsUnnaturalCorpse())
+				return false;
+			}
+			Pawn innerPawn = corpse.InnerPawn;
+			if (innerPawn.IsAndroid() || target.Thing.IsUnnaturalCorpse())
+			{
+				if (throwMessages)
 				{
-					if (throwMessages)
-					{
-						Messages.Message("WVC_PawnIsAndroidCheck".Translate(), innerPawn, MessageTypeDefOf.RejectInput, historical: false);
-					}
-					return false;
+					Messages.Message("WVC_PawnIsAndroidCheck".Translate(), innerPawn, MessageTypeDefOf.RejectInput, historical: false);
 				}
-				if (corpse.GetRotStage() == RotStage.Dessicated || !innerPawn.CanBleed() || innerPawn.health.hediffSet.TryGetHediff(HediffDefOf.BloodLoss, out Hediff hediff) && (hediff.Severity >= hediff.def.maxSeverity || hediff.Severity >= hediff.def.lethalSeverity))
+				return false;
+			}
+			if (corpse.GetRotStage() == RotStage.Dessicated || !innerPawn.CanBleed() || innerPawn.health.hediffSet.TryGetHediff(HediffDefOf.BloodLoss, out Hediff hediff) && (hediff.Severity >= hediff.def.maxSeverity || hediff.Severity >= hediff.def.lethalSeverity))
+			{
+				if (throwMessages)
 				{
-					if (throwMessages)
-					{
-						Messages.Message("WVC_XaG_CropsefeederNoBloodMessage".Translate(), innerPawn, MessageTypeDefOf.RejectInput, historical: false);
-					}
-					return false;
+					Messages.Message("WVC_XaG_CropsefeederNoBloodMessage".Translate(), innerPawn, MessageTypeDefOf.RejectInput, historical: false);
 				}
+				return false;
 			}
 			return base.Valid(target, throwMessages);
 		}

--- a/Source/Resources_Abilities/CompAbilityEffect_BodyPartsRipper_Corpse.cs
+++ b/Source/Resources_Abilities/CompAbilityEffect_BodyPartsRipper_Corpse.cs
@@ -52,20 +52,19 @@ namespace WVC_XenotypesAndGenes
 
         public override bool Valid(LocalTargetInfo target, bool throwMessages = false)
         {
-            if (throwMessages)
+            if (target.Thing is not Corpse corpse || corpse.InnerPawn == null || corpse.InnerPawn.RaceProps?.body != parent.pawn.RaceProps?.body)
             {
-                if (target.Thing is not Corpse corpse || corpse.InnerPawn.RaceProps.body != parent.pawn.RaceProps.body)
+                if (throwMessages)
                 {
                     SoundDefOf.ClickReject.PlayOneShotOnCamera();
-                    return false;
                 }
-                if (!Valid(parent, parent.pawn, corpse.InnerPawn, throwMessages))
-                {
-                    return false;
-                }
-                return base.Valid(target, throwMessages);
+                return false;
             }
-            return true;
+            if (!Valid(parent, parent.pawn, corpse.InnerPawn, throwMessages))
+            {
+                return false;
+            }
+            return base.Valid(target, throwMessages);
         }
 
         public static bool Valid(Ability ability, Pawn caster, Pawn victim, bool throwMessages = false, bool checkFaction = false)

--- a/Source/Resources_Abilities/CompAbilityEffect_Devourer.cs
+++ b/Source/Resources_Abilities/CompAbilityEffect_Devourer.cs
@@ -90,7 +90,7 @@ namespace WVC_XenotypesAndGenes
 			{
 				victim.Kill(new(DamageDefOf.ExecutionCut, 99999, 9999, instigator: caster));
 			}
-			victim.Corpse?.Kill(new(DamageDefOf.ExecutionCut, 99999, 9999, instigator: caster));
+			victim.Corpse?.Destroy();
 		}
 
 		private void IfVictimIsHumanlike(Pawn victim, Pawn caster, ref string phase)
@@ -98,12 +98,15 @@ namespace WVC_XenotypesAndGenes
 			phase = "change goodwill";
 			if (!victim.Dead && (victim.HomeFaction != null && !victim.HomeFaction.IsPlayer && !victim.HostileTo(caster.Faction) && victim.HomeFaction.HasGoodwill || victim.IsQuestLodger()))
 			{
-				int goodwillChange = (victim.RaceProps.Humanlike ? (-29) : (-21)) * (victim.guilt.IsGuilty ? 1 : 2);
-				if (victim.kindDef.factionHostileOnDeath || victim.kindDef.factionHostileOnKill && !victim.guilt.IsGuilty)
+				if (victim.HomeFaction != null)
 				{
-					goodwillChange = caster.Faction.GoodwillToMakeHostile(victim.HomeFaction);
+					int goodwillChange = (victim.RaceProps.Humanlike ? (-29) : (-21)) * (victim.guilt.IsGuilty ? 1 : 2);
+					if (victim.kindDef.factionHostileOnDeath || (victim.kindDef.factionHostileOnKill && !victim.guilt.IsGuilty))
+					{
+						goodwillChange = caster.Faction.GoodwillToMakeHostile(victim.HomeFaction);
+					}
+					victim.HomeFaction.TryAffectGoodwillWith(caster.Faction, goodwillChange, canSendMessage: true, true, reason: RimWorld.HistoryEventDefOf.MemberKilled);
 				}
-				victim.HomeFaction.TryAffectGoodwillWith(caster.Faction, goodwillChange, canSendMessage: true, true, reason: RimWorld.HistoryEventDefOf.MemberKilled);
 			}
 			//float genesFactor = 0.01f;
 			if (victim.IsHuman())

--- a/Source/Resources_Abilities/CompAbilityEffect_NewImplanter.cs
+++ b/Source/Resources_Abilities/CompAbilityEffect_NewImplanter.cs
@@ -100,9 +100,10 @@ namespace WVC_XenotypesAndGenes
 			{
 				return Dialog_MessageBox.CreateConfirmation("WarningPawnWillDieFromReimplanting".Translate(parent.pawn.Named("PAWN")), confirmAction, destructive: true);
 			}
-			if (target.Thing is Corpse corpse && !corpse.InnerPawn.guest.Recruitable && (corpse.InnerPawn.Faction == null || corpse.InnerPawn.Faction != Faction.OfPlayer))
+			if (target.Thing is Corpse corpse && corpse.InnerPawn.guest != null && !corpse.InnerPawn.guest.Recruitable && (corpse.InnerPawn.Faction == null || corpse.InnerPawn.Faction != Faction.OfPlayer))
 			{
-				return Dialog_MessageBox.CreateConfirmation("WVC_XaG_ReimplantResurrectionRecruiting_FailWarning".Translate(corpse.InnerPawn.Named("PAWN"), corpse.InnerPawn.Faction.NameColored.ToString()), confirmAction);
+				string factionName = corpse.InnerPawn.Faction != null ? corpse.InnerPawn.Faction.NameColored.ToString() : "NoFaction".Translate().ToString();
+				return Dialog_MessageBox.CreateConfirmation("WVC_XaG_ReimplantResurrectionRecruiting_FailWarning".Translate(corpse.InnerPawn.Named("PAWN"), factionName), confirmAction);
 			}
 			return null;
 		}

--- a/Source/Resources_Abilities/CompAbilityEffect_ReimplanterThrallMaker.cs
+++ b/Source/Resources_Abilities/CompAbilityEffect_ReimplanterThrallMaker.cs
@@ -308,57 +308,36 @@ namespace WVC_XenotypesAndGenes
 				//Messages.Message("WVC_XaG_ThrallMakerNonThrallSelected".Translate(), null, MessageTypeDefOf.RejectInput, historical: false);
 				return false;
 			}
-			if (target.HasThing && target.Thing is Corpse corpse)
+			if (!target.HasThing || target.Thing is not Corpse corpse || corpse.InnerPawn == null)
 			{
-				ThrallDef thrallDef = ReimplanterGene?.ThrallDef;
-				// if (ModsConfig.AnomalyActive && thrallDef.resurrectAsShambler)
-				// {
-				// if (!MutantUtility.CanResurrectAsShambler(corpse))
-				// {
-				// if (throwMessages)
-				// {
-				// Messages.Message("MessageCannotResurrectDessicatedCorpse".Translate(), corpse, MessageTypeDefOf.RejectInput, historical: false);
-				// }
-				// return false;
-				// }
-				// return true;
-				// }
-				Pawn innerPawn = corpse.InnerPawn;
-				MutantDef mutantDef = thrallDef?.mutantDef;
-				//if (thrallDef == null)
-				//{
-				//	if (throwMessages)
-				//	{
-				//		ReimplanterGene?.ThrallMakerDialog();
-				//		Messages.Message("WVC_XaG_ThrallMakerNonThrallSelected".Translate(), innerPawn, MessageTypeDefOf.RejectInput, historical: false);
-				//	}
-				//	return false;
-				//}
-				if (!innerPawn.IsHuman() || innerPawn.IsMutant && IsMutantOfTarget(innerPawn, mutantDef, thrallDef, corpse) || corpse.IsUnnaturalCorpse())
+				return false;
+			}
+			ThrallDef thrallDef = ReimplanterGene?.ThrallDef;
+			Pawn innerPawn = corpse.InnerPawn;
+			MutantDef mutantDef = thrallDef?.mutantDef;
+			if (!innerPawn.IsHuman() || innerPawn.IsMutant && IsMutantOfTarget(innerPawn, mutantDef, thrallDef, corpse) || corpse.IsUnnaturalCorpse())
+			{
+				if (throwMessages)
 				{
-					if (throwMessages)
-					{
-						Messages.Message("WVC_PawnIsAndroidCheck".Translate(), innerPawn, MessageTypeDefOf.RejectInput, historical: false);
-					}
-					return false;
+					Messages.Message("WVC_PawnIsAndroidCheck".Translate(), innerPawn, MessageTypeDefOf.RejectInput, historical: false);
 				}
-				if (mutantDef != null && !mutantDef.allowedDevelopmentalStages.HasAny(innerPawn.DevelopmentalStage))
+				return false;
+			}
+			if (mutantDef != null && !mutantDef.allowedDevelopmentalStages.HasAny(innerPawn.DevelopmentalStage))
+			{
+				if (throwMessages)
 				{
-					if (throwMessages)
-					{
-						//Log.Error("Def stages: " + mutantDef.allowedDevelopmentalStages.ToCommaList());
-						Messages.Message("WVC_XaG_WrongDevelopmentalStage".Translate(), innerPawn, MessageTypeDefOf.RejectInput, historical: false);
-					}
-					return false;
+					Messages.Message("WVC_XaG_WrongDevelopmentalStage".Translate(), innerPawn, MessageTypeDefOf.RejectInput, historical: false);
 				}
-				if (!thrallDef.acceptableRotStages.Contains(corpse.GetRotStage()))
+				return false;
+			}
+			if (!thrallDef.acceptableRotStages.Contains(corpse.GetRotStage()))
+			{
+				if (throwMessages)
 				{
-					if (throwMessages)
-					{
-						Messages.Message("WVC_XaG_MessageWrongRottingStage".Translate(), corpse, MessageTypeDefOf.RejectInput, historical: false);
-					}
-					return false;
+					Messages.Message("WVC_XaG_MessageWrongRottingStage".Translate(), corpse, MessageTypeDefOf.RejectInput, historical: false);
 				}
+				return false;
 			}
 			return base.Valid(target, throwMessages);
 

--- a/Source/Resources_Abilities/CompAbility_Validators.cs
+++ b/Source/Resources_Abilities/CompAbility_Validators.cs
@@ -217,7 +217,7 @@ namespace WVC_XenotypesAndGenes
 			//Log.Error("0");
 			GetReason(out reason, parent.pawn);
 			Cache(reason);
-			return false;
+			return cachedResult;
 		}
 
 		private void GetReason(out string reason, Pawn pawn)

--- a/Source/Resources_Abilities/CompProperties_AbilityChimera.cs
+++ b/Source/Resources_Abilities/CompProperties_AbilityChimera.cs
@@ -328,25 +328,18 @@ namespace WVC_XenotypesAndGenes
 
 		public override bool Valid(LocalTargetInfo target, bool throwMessages = false)
 		{
-			if (target.HasThing && target.Thing is Corpse corpse)
+			if (!target.HasThing || target.Thing is not Corpse corpse || corpse.InnerPawn == null)
 			{
-				Pawn innerPawn = corpse.InnerPawn;
-				if (!innerPawn.IsHuman())
+				return false;
+			}
+			Pawn innerPawn = corpse.InnerPawn;
+			if (!innerPawn.IsHuman())
+			{
+				if (throwMessages)
 				{
-					if (throwMessages)
-					{
-						Messages.Message("WVC_PawnIsAndroidCheck".Translate(), parent.pawn, MessageTypeDefOf.RejectInput, historical: false);
-					}
-					return false;
+					Messages.Message("WVC_PawnIsAndroidCheck".Translate(), parent.pawn, MessageTypeDefOf.RejectInput, historical: false);
 				}
-				//if (innerPawn.genes.GenesListForReading.Where((gene) => !ChimeraGene.AllGenes.Contains(gene.def)).ToList().Count <= 0)
-				//{
-				//    if (throwMessages)
-				//    {
-				//        Messages.Message("WVC_XaG_GeneChimera_TargetNoGenes".Translate(), target.Pawn, MessageTypeDefOf.RejectInput, historical: false);
-				//    }
-				//    return false;
-				//}
+				return false;
 			}
 			return base.Valid(target, throwMessages);
 		}

--- a/Source/Resources_Abilities/CompProperties_CorpseEater.cs
+++ b/Source/Resources_Abilities/CompProperties_CorpseEater.cs
@@ -43,9 +43,13 @@ namespace WVC_XenotypesAndGenes
 				int partCount = corpse.InnerPawn.health.hediffSet.GetNotMissingParts().ToList().Count;
 				for (int j = 0; j < partCount; j++)
 				{
+					if (corpse.Destroyed)
+					{
+						break;
+					}
 					IngestedCalculateAmounts(corpse, parent.pawn, neededNutrition, out float nutritionIngested);
 					nutritionGain += nutritionIngested;
-					neededNutrition -= nutritionGain;
+					neededNutrition -= nutritionIngested;
 					if (neededNutrition <= 0f)
 					{
 						break;

--- a/Source/Resources_DefWorkers/BloodeaterMode_Corpse.cs
+++ b/Source/Resources_DefWorkers/BloodeaterMode_Corpse.cs
@@ -33,9 +33,14 @@ namespace WVC_XenotypesAndGenes
 				return false;
 			}
 			// =
-			IEnumerable<Thing> targets = pawn.Map.listerThings.AllThings.Where((thing) => thing is Corpse corpse && !corpse.IsUnnaturalCorpse());
+			List<Thing> targets = pawn.Map.listerThings.ThingsInGroup(ThingRequestGroup.Corpse);
 			// =
 			foreach (Thing thing in targets)
+			{
+				if (thing is not Corpse corpse || corpse.IsUnnaturalCorpse())
+				{
+					continue;
+				}
 			{
 				if (thing is not Corpse corpse)
 				{

--- a/Source/Resources_DefWorkers/GolemlinkMode.cs
+++ b/Source/Resources_DefWorkers/GolemlinkMode.cs
@@ -204,14 +204,15 @@ namespace WVC_XenotypesAndGenes
 					//pawn.relations.AddDirectRelation(PawnRelationDefOf.Overseer, summon);
 					newGolem.ageTracker.AgeBiologicalTicks = dryad.ageTracker.AgeBiologicalTicks;
                     newGolem.ageTracker.AgeChronologicalTicks = dryad.ageTracker.AgeChronologicalTicks;
-                    if (!dryad.Name.Numerical)
+                    if (dryad.Name != null && !dryad.Name.Numerical)
 					{
 						newGolem.Name = dryad.Name;
 					}
 					newGolem.Rotation = dryad.Rotation;
 					MiscUtility.DoShapeshiftEffects_OnPawn(dryad);
 					dryad.Destroy();
-					Messages.Message("WVC_XaG_GolemCreatedFromRandomDryad_Message".Translate(newGolem.Name.ToString()), newGolem, MessageTypeDefOf.PositiveEvent);
+					string golemName = newGolem.Name?.ToString() ?? newGolem.LabelShort;
+					Messages.Message("WVC_XaG_GolemCreatedFromRandomDryad_Message".Translate(golemName), newGolem, MessageTypeDefOf.PositiveEvent);
 					return true;
 				}
 			}

--- a/Source/Resources_Genes/Gene_Anomaly.cs
+++ b/Source/Resources_Genes/Gene_Anomaly.cs
@@ -146,7 +146,7 @@ namespace WVC_XenotypesAndGenes
 			bool pause = true;
 			try
 			{
-				if (pawn.Map.listerThings.AllThings.TryRandomElement((Thing thing) => thing is Corpse && !thing.IsUnnaturalCorpse() && pawn.CanReach(thing, PathEndMode.Touch, Danger.Deadly), out Thing target))
+				if (pawn.Map.listerThings.ThingsInGroup(ThingRequestGroup.Corpse).TryRandomElement((Thing thing) => thing is Corpse corpse && !corpse.IsUnnaturalCorpse() && pawn.CanReach(thing, PathEndMode.Touch, Danger.Deadly), out Thing target))
 				{
 					GasUtility.AddDeadifeGas(target.PositionHeld, target.MapHeld, pawn.Faction, 30);
 					pause = false;

--- a/Source/Resources_Genes/Gene_ChimeraNetwork.cs
+++ b/Source/Resources_Genes/Gene_ChimeraNetwork.cs
@@ -58,6 +58,10 @@ namespace WVC_XenotypesAndGenes
 
 		public void ShareGenes()
 		{
+			if (Chimera == null)
+			{
+				return;
+			}
 			IEnumerable<Pawn> pawns = PawnsFinder.AllMapsCaravansAndTravellingTransporters_Alive_Colonists.Where((target) => target != pawn && target.genes != null);
 			if (!pawns.Any())
 			{
@@ -68,7 +72,7 @@ namespace WVC_XenotypesAndGenes
 			foreach (Pawn item in pawns)
 			{
 				Gene_ChimeraNetwork network = item.genes.GetFirstGeneOfType<Gene_ChimeraNetwork>();
-				if (network == null)
+				if (network?.Chimera == null)
 				{
 					continue;
 				}

--- a/Source/Resources_Genes/Gene_Chimera_PsychicHarvester.cs
+++ b/Source/Resources_Genes/Gene_Chimera_PsychicHarvester.cs
@@ -31,7 +31,14 @@ namespace WVC_XenotypesAndGenes
 		private void ResetTicker()
 		{
 			//IntRange range = new(44444, 67565);
-			updTick = Extension_Spawner.spawnIntervalRange.RandomInRange;
+			if (Extension_Spawner != null)
+			{
+				updTick = Extension_Spawner.spawnIntervalRange.RandomInRange;
+			}
+			else
+			{
+				updTick = 60000;
+			}
 		}
 
 		public override IEnumerable<Gizmo> GetGizmos()
@@ -205,7 +212,7 @@ namespace WVC_XenotypesAndGenes
 				List<Gene> genes = victim?.genes?.GenesListForReading;
 				if (genes.NullOrEmpty())
 				{
-					return;
+					continue;
 				}
 				if (Chimera.TryGetGene(XaG_GeneUtility.ConvertToDefs(genes), out GeneDef result))
 				{

--- a/Source/Resources_Genes/Gene_Clotting.cs
+++ b/Source/Resources_Genes/Gene_Clotting.cs
@@ -187,6 +187,10 @@ namespace WVC_XenotypesAndGenes
 				return;
 			}
 			List<Pawn> connectedThings = Gauranlen?.DryadsListForReading;
+			if (connectedThings == null)
+			{
+				return;
+			}
 			foreach (Pawn dryad in connectedThings)
 			{
 				Gene_ClottingWithHediff.WoundsClotting(dryad, new(0.4f, 0.8f));

--- a/Source/Resources_Genes/Gene_Gender.cs
+++ b/Source/Resources_Genes/Gene_Gender.cs
@@ -78,7 +78,7 @@ namespace WVC_XenotypesAndGenes
 				{
 					pawn.Name = new NameTriple(nameTriple.First, nameTriple.First, nameTriple.Last);
 				}
-				if (!pawn.style.CanWantBeard && pawn.style.beardDef != BeardDefOf.NoBeard)
+				if (pawn.style != null && !pawn.style.CanWantBeard && pawn.style.beardDef != BeardDefOf.NoBeard)
 				{
 					pawn.style.beardDef = BeardDefOf.NoBeard;
 				}

--- a/Source/Resources_Genes/Gene_GolemlinkSubGene.cs
+++ b/Source/Resources_Genes/Gene_GolemlinkSubGene.cs
@@ -148,14 +148,15 @@ namespace WVC_XenotypesAndGenes
 					//pawn.relations.AddDirectRelation(PawnRelationDefOf.Overseer, summon);
 					newGolem.ageTracker.AgeBiologicalTicks = dryad.ageTracker.AgeBiologicalTicks;
 					newGolem.ageTracker.AgeChronologicalTicks = dryad.ageTracker.AgeChronologicalTicks;
-					if (!dryad.Name.Numerical)
+					if (dryad.Name != null && !dryad.Name.Numerical)
 					{
 						newGolem.Name = dryad.Name;
 					}
 					newGolem.Rotation = dryad.Rotation;
 					EffectsUtility.DoShapeshiftEffects_OnPawn(dryad);
 					dryad.Destroy();
-					Messages.Message("WVC_XaG_GolemCreatedFromRandomDryad_Message".Translate(newGolem.Name.ToString()), newGolem, MessageTypeDefOf.PositiveEvent);
+					string golemName = newGolem.Name?.ToString() ?? newGolem.LabelShort;
+					Messages.Message("WVC_XaG_GolemCreatedFromRandomDryad_Message".Translate(golemName), newGolem, MessageTypeDefOf.PositiveEvent);
 					return true;
 				}
 			}

--- a/Source/Resources_Genes/Gene_InStability.cs
+++ b/Source/Resources_Genes/Gene_InStability.cs
@@ -393,6 +393,10 @@ namespace WVC_XenotypesAndGenes
 			{
 				return;
 			}
+			if (Extension_Giver?.specialFoodDefs.NullOrEmpty() != false)
+			{
+				return;
+			}
 			List<Thing> things = caravan.AllThings.ToList();
 			if (things.NullOrEmpty())
 			{

--- a/Source/Resources_Genes/Gene_ResurgentCellsGain.cs
+++ b/Source/Resources_Genes/Gene_ResurgentCellsGain.cs
@@ -236,13 +236,17 @@ namespace WVC_XenotypesAndGenes
 		private int CountSpecialTrees()
 		{
 			int trees = 0;
-			foreach (Thing item in pawn.Map.listerThings.AllThings)
+			if (pawn.Map == null || Extension_Spawner?.incidentDef?.treeDef == null)
 			{
-				if (item?.def != Extension_Spawner.incidentDef.treeDef)
+				return 0;
+			}
+			List<Thing> list = pawn.Map.listerThings.ThingsOfDef(Extension_Spawner.incidentDef.treeDef);
+			for (int i = 0; i < list.Count; i++)
+			{
+				if (list[i] != null)
 				{
-					continue;
+					trees++;
 				}
-				trees++;
 			}
 			return trees;
 		}

--- a/Source/Resources_Holders/XenotypeHolder_Exposable.cs
+++ b/Source/Resources_Holders/XenotypeHolder_Exposable.cs
@@ -95,8 +95,8 @@ namespace WVC_XenotypesAndGenes
 		{
 			if (parent1 == null && parent2 != null || parent2 == null && parent1 != null)
 			{
-				XenotypeDef parentXenotype = parent1 != null ? parent1.genes.Xenotype : parent2.genes.Xenotype;
-				if (parentXenotype.inheritable)
+				XenotypeDef parentXenotype = parent1 != null ? parent1.genes?.Xenotype : parent2.genes?.Xenotype;
+				if (parentXenotype != null && parentXenotype.inheritable)
 				{
 					this.xenotypeDef = parentXenotype;
 				}

--- a/Source/Resources_RitualAttachableOutcome/RitualAttachableOutcomeEffectWorker_XenotypeRecruit.cs
+++ b/Source/Resources_RitualAttachableOutcome/RitualAttachableOutcomeEffectWorker_XenotypeRecruit.cs
@@ -17,9 +17,9 @@ namespace WVC_XenotypesAndGenes
 		public override void Apply(Dictionary<Pawn, int> totalPresence, LordJob_Ritual jobRitual, RitualOutcomePossibility outcome, out string extraOutcomeDesc, ref LookTargets letterLookTargets)
 		{
 			extension = def?.GetModExtension<GeneExtension_General>();
-			if (extension != null && extension.xenotypeChances.TryRandomElementByWeight((XenotypeChance xenoChance) => xenoChance.chance, out XenotypeChance xenoChance))
+			if (extension != null && extension.xenotypeChances.TryRandomElementByWeight((XenotypeChance xc) => xc.chance, out XenotypeChance chosenXenoChance))
 			{
-				this.xenotypeChance = xenoChance;
+				this.xenotypeChance = chosenXenoChance;
 				recruitChance = extension.recruitChance;
 			}
 			if (Rand.Chance(recruitChance))

--- a/Source/Resources_ScenPart/ScenPart_PawnModifier_XenotypesAndGenes.cs
+++ b/Source/Resources_ScenPart/ScenPart_PawnModifier_XenotypesAndGenes.cs
@@ -120,8 +120,8 @@ namespace WVC_XenotypesAndGenes
 
 		public override IEnumerable<Thing> PlayerStartingThings()
 		{
-			Pawn pawn = Find.GameInitData.startingAndOptionalPawns.Take(Find.GameInitData.startingPawnCount).First();
-			if (humanEggDef != null && pawn.genes?.GetFirstGeneOfType<Gene_Ovipositor>() != null)
+			Pawn pawn = Find.GameInitData?.startingAndOptionalPawns?.Take(Find.GameInitData.startingPawnCount).FirstOrDefault();
+			if (pawn != null && humanEggDef != null && pawn.genes?.GetFirstGeneOfType<Gene_Ovipositor>() != null)
 			{
 				Thing thing = ThingMaker.MakeThing(humanEggDef);
 				thing.stackCount = humanEggsCount.RandomInRange;

--- a/Source/Resources_Things/Building_MechCharger.cs
+++ b/Source/Resources_Things/Building_MechCharger.cs
@@ -199,7 +199,7 @@ namespace WVC_XenotypesAndGenes
 		protected override void Tick()
 		{
 			base.Tick();
-			if (currentlyChargingMech != null && (RechargeableStomach == null || currentlyChargingMech.CurJob.targetA.Thing != this))
+			if (currentlyChargingMech != null && (RechargeableStomach == null || currentlyChargingMech.CurJob == null || currentlyChargingMech.CurJob.targetA.Thing != this))
 			{
 				Log.Warning("Xenos did not clean up his charging job properly");
 				StopCharging();
@@ -272,17 +272,17 @@ namespace WVC_XenotypesAndGenes
 					job.overrideFacing = Rot4.South;
 					selPawn.jobs.TryTakeOrderedJob(job, JobTag.Misc, false);
 				}), selPawn, this);
-				Gene_HemogenRecharge gene2 = selPawn?.genes?.GetFirstGeneOfType<Gene_HemogenRecharge>();
-				if (gene2?.Extension_Giver?.xenoChargerDef == def)
+			}
+			Gene_HemogenRecharge gene2 = selPawn?.genes?.GetFirstGeneOfType<Gene_HemogenRecharge>();
+			if (gene2?.Extension_Giver?.xenoChargerDef == def)
+			{
+				// Log.Error("1");
+				yield return FloatMenuUtility.DecoratePrioritizedTask(new FloatMenuOption("WVC_ForceHemogenRecharge".Translate(), delegate
 				{
-					// Log.Error("1");
-					yield return FloatMenuUtility.DecoratePrioritizedTask(new FloatMenuOption("WVC_ForceHemogenRecharge".Translate(), delegate
-					{
-						Job job = JobMaker.MakeJob(gene2.Extension_Giver.rechargeableStomachJobDef, this);
-						job.overrideFacing = Rot4.South;
-						selPawn.jobs.TryTakeOrderedJob(job, JobTag.Misc, false);
-					}), selPawn, this);
-				}
+					Job job = JobMaker.MakeJob(gene2.Extension_Giver.rechargeableStomachJobDef, this);
+					job.overrideFacing = Rot4.South;
+					selPawn.jobs.TryTakeOrderedJob(job, JobTag.Misc, false);
+				}), selPawn, this);
 			}
 			// Log.Error("End 0");
 		}

--- a/Source/Resources_Things/CompBackupSummonPawns.cs
+++ b/Source/Resources_Things/CompBackupSummonPawns.cs
@@ -55,7 +55,7 @@ namespace WVC_XenotypesAndGenes
 
 		public override IEnumerable<Gizmo> CompGetGizmosExtra()
 		{
-			if (!CanSummon() || StaticCollectionsClass.GameComponent == null)
+			if (!CanSummon() || StaticCollectionsClass.GameComponent == null || parent.MapHeld == null)
 			{
 				yield break;
 			}

--- a/Source/Resources_Things/CompProperties_AffectedByFacilities.cs
+++ b/Source/Resources_Things/CompProperties_AffectedByFacilities.cs
@@ -55,6 +55,10 @@ namespace WVC_XenotypesAndGenes
 
         public static void SetHyperLinks(ThingDef parentDef, List<ThingDef> linkableFacilities)
         {
+            if (linkableFacilities.NullOrEmpty())
+            {
+                return;
+            }
             foreach (ThingDef thingDef in linkableFacilities)
             {
                 if (thingDef.descriptionHyperlinks.NullOrEmpty())

--- a/Source/Resources_Things/CompProperties_DryadCocoon.cs
+++ b/Source/Resources_Things/CompProperties_DryadCocoon.cs
@@ -94,7 +94,7 @@ namespace WVC_XenotypesAndGenes
 				{
 					parent.Destroy();
 				}
-				else if (Dryad.Dead || Dryad.Destroyed)
+				else if (Dryad == null || Dryad.Dead || Dryad.Destroyed)
 				{
 					parent.Destroy();
 				}
@@ -194,7 +194,7 @@ namespace WVC_XenotypesAndGenes
 				DryadComp.Gene_DryadQueen.RemoveDryad(pawn);
 				Pawn pawn2 = DryadComp.Gene_DryadQueen.GenerateNewDryad(DryadComp.DryadKind);
 				pawn2.ageTracker.AgeBiologicalTicks = ageBiologicalTicks;
-				if (!pawn.Name.Numerical)
+				if (pawn.Name != null && !pawn.Name.Numerical)
 				{
 					pawn2.Name = pawn.Name;
 				}

--- a/Source/Resources_Things/CompProperties_HumanEgg.cs
+++ b/Source/Resources_Things/CompProperties_HumanEgg.cs
@@ -151,7 +151,7 @@ namespace WVC_XenotypesAndGenes
 				if (mother?.genes?.Xenotype == father?.genes?.Xenotype || AnyParentIsNull())
 				{
 					child.genes.SetXenotypeDirect(pawn?.genes?.Xenotype);
-					if (pawn.genes.Xenotype == XenotypeDefOf.Baseliner)
+					if (pawn?.genes?.Xenotype == XenotypeDefOf.Baseliner)
 					{
 						child.genes.xenotypeName = pawn.genes.xenotypeName;
 						child.genes.iconDef = pawn.genes.iconDef;

--- a/Source/Resources_Utility/EffectsUtility.cs
+++ b/Source/Resources_Utility/EffectsUtility.cs
@@ -19,6 +19,10 @@ namespace WVC_XenotypesAndGenes
 
 		public static void DoSkipEffects(IntVec3 spawnCell, Map map)
 		{
+			if (map == null)
+			{
+				return;
+			}
 			map.effecterMaintainer.AddEffecterToMaintain(EffecterDefOf.Skip_EntryNoDelay.Spawn(spawnCell, map), spawnCell, 60);
 			SoundDefOf.Psycast_Skip_Entry.PlayOneShot(new TargetInfo(spawnCell, map));
 		}


### PR DESCRIPTION
I may have gone a bit overboard with my fix's feel free to cherrypick what you like, or just yeet this pull request if you want.

- fixed null reference exceptions when reimplanting factionless corpses, checking pawn styles, accessing dryad names/holders, and inspecting facilities
- fixed invalid cast exceptions in corpse feeder, corpse harvester, and thrall maker target validations
- fixed GizmoDisabled logic in ability validators to properly report disabled status
- fixed corpse eater nutrition subtraction calculation and added destruction checks
- un-nested hemogen recharge float menu options and null-checked current job on xeno chargers
- optimized map-wide corpse lookups and special tree counting by switching from AllThings to dedicated ListerThings methods
- added null map check in skip effects utility and null MapHeld check in backup summon pawns gizmo
- fixed variable shadowing in xenotype recruit ritual outcome worker and added null checks for starting pawns in scenario parts